### PR TITLE
Reduce range to 1 month

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -22,7 +22,7 @@ class StatsController < ApplicationController
   end
 
   def index
-    ago = (params[:months] || "24").to_i
+    ago = (params[:months] || "1").to_i
     step = 1.day
     current_date = ago.months.ago.beginning_of_day
     end_date   = Time.zone.now.beginning_of_day


### PR DESCRIPTION
Going through 2 years of history isn't required for most projects. This
commit reduces the time range from 2 years to only 1 month.
