### PR TITLE
[#126195063] Use the correct PT tracker api method to retrieve a story

### DIFF
--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -221,7 +221,7 @@ class Grouping < ActiveRecord::Base
   end
 
   def accept_tracker_story
-    tracker = Watcher.retrieve_system_account.tracker
+    tracker = Watcher.retrieve_system_account.tracker.client
     return unless tracker.present?
 
     story = tracker.story(pivotal_tracker_story_id)

--- a/spec/models/grouping_spec.rb
+++ b/spec/models/grouping_spec.rb
@@ -384,11 +384,18 @@ describe Grouping do
 
     context "if there is an associated tracker story" do
       let(:tracker_id) { "some-tracker-id" }
+      let(:tracker_stub) { double(:tracker_client) }
+      let(:story_stub) { double(:story) }
 
       before { grouping.update! pivotal_tracker_story_id: tracker_id }
 
       it "accepts the story and adds a note" do
-        expect(grouping).to receive(:accept_tracker_story)
+        expect(grouping).to receive(:accept_tracker_story).and_call_original
+        expect_any_instance_of(Tracker).to receive(:client) { tracker_stub }
+        expect(tracker_stub).to receive(:story).with(tracker_id).and_return(story_stub)
+        expect(story_stub).to receive(:current_state)
+        expect(story_stub).to receive(:update).with("current_state" => "accepted")
+        expect(story_stub).to receive_message_chain(:notes, :create)
         subject
       end
     end


### PR DESCRIPTION
I used the client incorrectly in the integration. I've updated the spec to more thoroughly test the integration to fix this wat: 

https://wattle.omadahealth.net/groupings/1060622?utf8=%E2%9C%93&filters%5Bapp_name%5D%5B%5D=Kairos&filters%5Bapp_name%5D%5B%5D=Mailer&filters%5Bapp_name%5D%5B%5D=Omadalabs&filters%5Bapp_name%5D%5B%5D=Wattle&filters%5Bapp_env%5D%5B%5D=demo&filters%5Bapp_env%5D%5B%5D=production&filters%5Bapp_env%5D%5B%5D=staging
