### PR TITLE
[#126195263] Add default values for the daily_grouping_updater to accommodate the inability to use named parameters in sidekiq-cron

### DIFF
--- a/app/workers/daily_grouping_updater.rb
+++ b/app/workers/daily_grouping_updater.rb
@@ -5,7 +5,7 @@ class DailyGroupingUpdater
     @system_account = Watcher.retrieve_system_account
   end
 
-  def perform(app_name:, time_frame: 15.days.ago)
+  def perform(app_name: WatConfig.secret_value('SYSTEM_ACCOUNT_APPS'), time_frame: 15.days.ago)
     groupings = Grouping.app_name(app_name).retrieve_stale_groupings(time_frame)
     groupings.each do |grouping|
       grouping.whodunnit(@system_account) do

--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -2,6 +2,4 @@
 daily_grouping_updater:
   cron: "0 3 * * *"
   class: "DailyGroupingUpdater"
-  args:
-    app_name: <%= WatConfig.secret_value('SYSTEM_ACCOUNT_APPS') %>
 <% end %>


### PR DESCRIPTION
Named parameters don't work will with sidekiq-cron since the parsed yaml has string keys instead of symbols. This was discovered by the following wat:

https://wattle.omadahealth.net/groupings/1060677?utf8=%E2%9C%93&filters%5Bapp_name%5D%5B%5D=Kairos&filters%5Bapp_name%5D%5B%5D=Mailer&filters%5Bapp_name%5D%5B%5D=Omadalabs&filters%5Bapp_name%5D%5B%5D=Wattle&filters%5Bapp_env%5D%5B%5D=demo&filters%5Bapp_env%5D%5B%5D=production&filters%5Bapp_env%5D%5B%5D=staging

This update places the default values in the method itself to avoid having to deal with the problem.
