### PR TITLE
[#126331443] Allow either error_class or message to be used in the creation of a PT story

### DIFF
--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -217,7 +217,7 @@ class Grouping < ActiveRecord::Base
   end
 
   def tracker_story_name
-    "Grouping #{id}: #{message} - Users: #{app_user_count} - Wats: #{wats.size}"
+    "Grouping #{id}: #{error_class || message} - Users: #{app_user_count} - Wats: #{wats.size}"
   end
 
   def accept_tracker_story

--- a/spec/models/grouping_spec.rb
+++ b/spec/models/grouping_spec.rb
@@ -367,9 +367,20 @@ describe Grouping do
 
     it "returns the approriate values for the tracker story name" do
       expect(subject).to include grouping.id.to_s
-      expect(subject).to include grouping.message.to_s
       expect(subject).to include grouping.app_user_count.to_s
       expect(subject).to include grouping.wats.size.to_s
+    end
+
+    context "if there is only an error_class of the error" do
+      before { grouping.update! error_class: "SomeErrorClass", message: nil }
+
+      it { is_expected.to include grouping.error_class }
+    end
+
+    context "if there is only a message of the error" do
+      before { grouping.update! error_class: nil, message: "some error message" }
+
+      it { is_expected.to include grouping.message }
     end
   end
 


### PR DESCRIPTION
Turns out that `message` isn't always a column that has a value. For ruby wats, an `error_class` value is set and for js wats the `message` is set. This PR will allow either to be used in generating the PT tracker story name - whichever is present.
