### PR TITLE
[#127369831] Auto-label PT created stories with the language of the grouping

### DIFF
--- a/app/controllers/trackers_controller.rb
+++ b/app/controllers/trackers_controller.rb
@@ -6,7 +6,8 @@ class TrackersController < ApplicationController
     description = "[View grouping #{@grouping.id} in Wattle](#{grouping_url(@grouping)})"
     story = current_user.tracker.create_story(story_params[:tracker_project],
       name: story_name,
-      description: description
+      description: description,
+      labels: [@grouping.language]
     )
 
     @grouping.update!(pivotal_tracker_story_id: story.id)

--- a/spec/controllers/trackers_controller_spec.rb
+++ b/spec/controllers/trackers_controller_spec.rb
@@ -17,6 +17,11 @@ describe TrackersController, type: :controller do
       it "updates grouping with the new story id" do
         expect { subject }.to change { grouping.reload.pivotal_tracker_story_id }.from(nil)
       end
+
+      it "uses the language to label the story" do
+        expect_any_instance_of(Grouping).to receive(:language)
+        subject
+      end
     end
   end
 end


### PR DESCRIPTION
This PR makes the PT story creation feature a little more detailed by adding the language of the grouping to the newly created story as a label.
